### PR TITLE
Check continuation in getChannelPlaylistsMore()

### DIFF
--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -196,7 +196,7 @@ class YoutubeGrabber {
     }
 
     const continuationData = channelPageResponse.data[1].response.continuationContents.gridContinuation
-    const nextContinuation = continuationData.continuations[0].nextContinuationData.continuation
+    const nextContinuation = continuationData.continuations ? continuationData.continuations[0].nextContinuationData.continuation : null
     const channelMetaData = channelPageResponse.data[1].response.metadata.channelMetadataRenderer
     const channelName = channelMetaData.title
     const channelId = channelMetaData.externalId


### PR DESCRIPTION
In getChannelPlaylistsMore(), there is no check on whether continuation data is available and therefore fails when there is no further continuation that can be obtained from the response (happens when you are fetching the last page of playlists).

