### PR TITLE
Add isVerified boolean to channel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ ytch.getChannelInfo(channelId).then((response) => {
    description: String,
    isFamilyFriendly: Boolean,
    relatedChannels: Array[Object],
-   allowedRegions: Array[String]
+   allowedRegions: Array[String],
+   isVerified: Boolean,
 }
 ```
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -99,6 +99,11 @@ class YoutubeGrabber {
         subscriberCount = subscriberNumber
     }
 
+    let isVerified = false
+    if (channelHeaderData.badges) {
+      isVerified = channelHeaderData.badges.some((badge) => badge.metadataBadgeRenderer.tooltip === 'Verified')
+    }
+
     const channelInfo = {
       author: channelMetaData.title,
       authorId: channelMetaData.externalId,
@@ -110,7 +115,8 @@ class YoutubeGrabber {
       description: channelMetaData.description,
       isFamilyFriendly: channelMetaData.isFamilySafe,
       relatedChannels: relatedChannels,
-      allowedRegions: channelMetaData.availableCountryCodes
+      allowedRegions: channelMetaData.availableCountryCodes,
+      isVerified: isVerified
     }
 
     return channelInfo


### PR DESCRIPTION
I needed this for a personal project, and thought why not contribute it to the main repository.

Anyways, this PR adds a boolean to the channel info for if the channel is verified, by looking at the returned json's badges and checking if there's one that says 'Verified'.

I looked at modifying the tests for this change, but it seems those are a bit out of date, so I didn't do that. I did update the README though.