### PR TITLE
fixed error when requesting last continuation

### DIFF
--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -156,7 +156,7 @@ class YoutubeGrabber {
       return typeof (item.continuationItemRenderer) !== 'undefined'
     })
 
-    if (typeof continuationItem !== 'undefined') {
+    if (typeof continuationItem !== 'undefined' && typeof continuationItem[0] !== 'undefined') {
       nextContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
     }
 
@@ -215,7 +215,7 @@ class YoutubeGrabber {
       return typeof (item.continuationItemRenderer) !== 'undefined'
     })
 
-    if (typeof continuationItem !== 'undefined') {
+    if (typeof continuationItem !== 'undefined' && typeof continuationItem[0] !== 'undefined') {
       nextContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
     }
 


### PR DESCRIPTION
This error appears, when requesting the last continuation. With this little fix it now works fine.

```
node_modules\yt-channel-info\app\youtube-grabber.js:160
      nextContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
                                             ^

TypeError: Cannot read property 'continuationItemRenderer' of undefined
    at Function.getChannelVideosMore (node_modules\yt-channel-info\app\youtube-grabber.js:160:46)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)

```

The problem was that _continuationItem_ was not _undefined_, but an _empty array_.