### PR TITLE
Fix viewCount for live videos

### DIFF
--- a/app/helper.js
+++ b/app/helper.js
@@ -92,7 +92,7 @@ class YoutubeGrabberHelper {
     if (typeof (video.shortViewCountText) !== 'undefined' && typeof (video.shortViewCountText.simpleText) === 'undefined') {
       liveNow = true
       publishedText = 'Live'
-      viewCount = parseInt(video.shortViewCountText.runs[0].text)
+      viewCount = parseInt(video.viewCountText.runs[0].text.split(',').join(''))
       viewCountText = video.shortViewCountText.runs[0].text + video.shortViewCountText.runs[1].text
     } else if (typeof (statusRenderer) !== 'undefined' && typeof (statusRenderer.text) !== 'undefined' && typeof (statusRenderer.text.runs) !== 'undefined') {
       premiere = true


### PR DESCRIPTION
Hi! 

I found this small bug using FreeTube (which is awesome by the way! 👏️).
The `viewCount` is parsed incorrectly when a live video has more than a thousand viewers.

![image](https://user-images.githubusercontent.com/57290334/108738150-9a73e300-7533-11eb-9853-6280e4efcb8d.png)

I parsed the value from `viewCountText` instead of `shortViewCountText`.

![image](https://user-images.githubusercontent.com/57290334/108738187-a3fd4b00-7533-11eb-9956-671da1362572.png)
