### PR TITLE
Add getRelatedChannelsMore() to fix error in getting channel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ ytch.getChannelInfo(channelId).then((response) => {
    relatedChannels: Array[Object],
    allowedRegions: Array[String],
    isVerified: Boolean,
+   relatedChannelsContinuation: String // Will return null if there are 12 or fewer related channels.  Used with getRelatedChannelsMore()
 }
 ```
 
@@ -186,6 +187,26 @@ ytch.searchChannelMore(continuation).then((response) => {
  {
    items: Array[Object],
    continuation: String // Will return null if no more results can be found.  Used with searchChannelMore()
+ }
+ ```
+
+**getRelatedChannelsMore(continuation)**
+
+ Grabs more related channels within a channel.  Uses the relatedChannelsContinuation string returned from `getChannelInfo()` or from past calls to `getRelatedChannelsMore()`.
+
+  ```javascript
+ const continuation = '4qmFsgKlARIYVUNtOUs2cmJ5OThXOEppZ0xvWk9oNkZRGlhFZ2hqYUdGdWJtVnNjeGdESUFBd0FUZ0I2Z01vUTJkQlUwZG9iMWxXVlU1M1pXdHNVR1ZzUW5saE1IaGhXWHBhWm1SV1NsSldWazQyVG5wa1VnJTNEJTNEmgIuYnJvd3NlLWZlZWRVQ205SzZyYnk5OFc4SmlnTG9aT2g2RlFjaGFubmVsczE1Ng%3D%3D'
+
+ytch.getRelatedChannelsMore(continuation).then((response) => {
+   console.log(response)
+}).catch((err) => {
+   console.log(err)
+})
+
+ // Response object
+ {
+   relatedChannels: Array[Object],
+   relatedChannelsContinuation: String // Will return null if no more results can be found.  Used with getRelatedChannelsMore()
  }
  ```
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ ytch.getChannelInfo(channelId).then((response) => {
    subscriberCount: Integer,
    description: String,
    isFamilyFriendly: Boolean,
-   relatedChannels: Array[Object],
+   relatedChannels: {
+      items: Array[Object],
+      continuation: String // Will return null if there are 12 or fewer related channels.  Used with getRelatedChannelsMore()
+   },
    allowedRegions: Array[String],
-   isVerified: Boolean,
-   relatedChannelsContinuation: String // Will return null if there are 12 or fewer related channels.  Used with getRelatedChannelsMore()
+   isVerified: Boolean
 }
 ```
 
@@ -205,8 +207,8 @@ ytch.getRelatedChannelsMore(continuation).then((response) => {
 
  // Response object
  {
-   relatedChannels: Array[Object],
-   relatedChannelsContinuation: String // Will return null if no more results can be found.  Used with getRelatedChannelsMore()
+   items: Array[Object],
+   continuation: String // Will return null if no more results can be found.  Used with getRelatedChannelsMore()
  }
  ```
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -139,10 +139,12 @@ class YoutubeGrabber {
       subscriberCount: subscriberCount,
       description: channelMetaData.description,
       isFamilyFriendly: channelMetaData.isFamilySafe,
-      relatedChannels: relatedChannels,
+      relatedChannels: {
+        items: relatedChannels,
+        continuation: relatedChannelsContinuation
+      },
       allowedRegions: channelMetaData.availableCountryCodes,
-      isVerified: isVerified,
-      relatedChannelsContinuation: relatedChannelsContinuation
+      isVerified: isVerified
     }
 
     return channelInfo
@@ -201,8 +203,8 @@ class YoutubeGrabber {
     })
 
     return {
-      relatedChannels: relatedChannels,
-      relatedChannelsContinuation: nextContinuation
+      items: relatedChannels,
+      continuation: nextContinuation
     }
   }
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -46,9 +46,12 @@ class YoutubeGrabber {
     const featuredChannels = channelsTab[0].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0]
 
     let relatedChannels = []
+    let relatedChannelsContinuation = null
 
     if (typeof (featuredChannels.gridRenderer) !== 'undefined') {
-      relatedChannels = featuredChannels.gridRenderer.items.map((channel) => {
+      relatedChannels = featuredChannels.gridRenderer.items.filter((channel) => {
+        return typeof (channel.gridChannelRenderer) !== 'undefined'
+      }).map((channel) => {
         const author = channel.gridChannelRenderer
         let channelName
 
@@ -65,6 +68,16 @@ class YoutubeGrabber {
           authorThumbnails: author.thumbnail.thumbnails,
         }
       })
+
+      const continuationData = featuredChannels.gridRenderer.items
+
+      const continuationItem = continuationData.filter((item) => {
+        return typeof (item.continuationItemRenderer) !== 'undefined'
+      })
+
+      if (typeof continuationItem !== 'undefined' && typeof continuationItem[0] !== 'undefined') {
+        relatedChannelsContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
+      }
     }
 
     let subscriberText
@@ -124,10 +137,69 @@ class YoutubeGrabber {
       isFamilyFriendly: channelMetaData.isFamilySafe,
       relatedChannels: relatedChannels,
       allowedRegions: channelMetaData.availableCountryCodes,
-      isVerified: isVerified
+      isVerified: isVerified,
+      relatedChannelsContinuation: relatedChannelsContinuation
     }
 
     return channelInfo
+  }
+
+  static async getRelatedChannelsMore (continuation) {
+    const urlParams = {
+      context: {
+        client: {
+          clientName: 'WEB',
+          clientVersion: '2.20201021.03.00',
+        },
+      },
+      continuation: continuation
+    }
+    const ajaxUrl = 'https://www.youtube.com/youtubei/v1/browse?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8'
+
+    const channelPageResponse = await YoutubeGrabberHelper.makeChannelPost(ajaxUrl, urlParams)
+
+    if (channelPageResponse.error) {
+      return Promise.reject(channelPageResponse.message)
+    }
+
+    let nextContinuation = null
+
+    const continuationData = channelPageResponse.data.onResponseReceivedActions[0].appendContinuationItemsAction.continuationItems
+
+    const continuationItem = continuationData.filter((item) => {
+      return typeof (item.continuationItemRenderer) !== 'undefined'
+    })
+
+    if (typeof continuationItem !== 'undefined' && typeof continuationItem[0] !== 'undefined') {
+      nextContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
+    }
+
+    let relatedChannels = []
+
+    relatedChannels = continuationData.filter((channel) => {
+      return typeof (channel.gridChannelRenderer) !== 'undefined'
+    }).map((channel) => {
+      const author = channel.gridChannelRenderer
+      let channelName
+
+      if (typeof (author.title.runs) !== 'undefined') {
+        channelName = author.title.runs[0].text
+      } else {
+        channelName = author.title.simpleText
+      }
+
+      return {
+        author: channelName,
+        authorId: author.channelId,
+        authorUrl: author.navigationEndpoint.browseEndpoint.canonicalBaseUrl,
+        authorThumbnails: author.thumbnail.thumbnails,
+      }
+    })
+
+    return {
+      relatedChannels: relatedChannels,
+      relatedChannelsContinuation: nextContinuation
+    }
   }
 
   static async getChannelVideos (channelId, sortBy = 'newest') {


### PR DESCRIPTION
There is [a bug in the latest version of FreeTube](https://github.com/FreeTubeApp/FreeTube/issues/1101)  that prevents some channels from properly loading. The underlying problem is that on channels with more than 12 related channels, there is an unhandled continuation token for getting more related channels.

This pull request revises `getChannelInfo()` to return just the first 12 related channels, along with the `relatedChannelsContinuation` if relevant. It additionally adds `getRelatedChannelsMore()` to get further related channels.

I tried my best to make the new functions consistent with the existing continuation code, though there is a difference in how I name some variables.  The other continuation functions, like `getChannelVideos()`, use `items` and `continuation` naming,  but since `getChannelInfo()` returns many other values, it may be confusing to use these variable names. Thus, this pull request uses the variable names `relatedChannels` and `relatedChannelsContinuation`, both in `getChannelInfo()` and `getRelatedChannelsMore()` for consistency.

If you have any input on variable naming or anything else related to this pull request, please let me know.