### PR TITLE
/c/ Channel URL Support

### DIFF
--- a/app/fetchers/channel.js
+++ b/app/fetchers/channel.js
@@ -16,7 +16,11 @@ class YoutubeChannelFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/videos?flow=grid&view=0&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 
@@ -33,7 +37,11 @@ class YoutubeChannelFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/videos?view=0&sort=da&flow=grid&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 
@@ -50,7 +58,11 @@ class YoutubeChannelFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/videos?view=0&sort=p&flow=grid&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 

--- a/app/fetchers/playlist.js
+++ b/app/fetchers/playlist.js
@@ -16,7 +16,11 @@ class PlaylistFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/playlists?flow=grid&view=1&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 
@@ -33,7 +37,11 @@ class PlaylistFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/playlists?view=1&sort=da&flow=grid&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 
@@ -50,7 +58,11 @@ class PlaylistFetcher {
       channelPageResponse = await helper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/playlists?view=1&sort=dd&flow=grid&pbj=1`
+        channelPageResponse = await helper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -22,7 +22,11 @@ class YoutubeGrabber {
       channelPageResponse = await YoutubeGrabberHelper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/channels?flow=grid&view=0&pbj=1`
+        channelPageResponse = await YoutubeGrabberHelper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 
@@ -277,7 +281,11 @@ class YoutubeGrabber {
       channelPageResponse = await YoutubeGrabberHelper.makeChannelRequest(userUrl)
 
       if (channelPageResponse.error) {
-        return Promise.reject(channelPageResponse.message)
+        const cUrl = `https://youtube.com/c/${channelId}/search?${urlParams}`
+        channelPageResponse = await YoutubeGrabberHelper.makeChannelRequest(cUrl)
+        if (channelPageResponse.error) {
+          return Promise.reject(channelPageResponse.message)
+        }
       }
     }
 


### PR DESCRIPTION
With the changes from Svallinn at https://github.com/FreeTubeApp/FreeTube/pull/1148 we also need the possibility to use these links as their new kind of user id can be linked as well, and the other two URLs cannot work with this id.

An example link looks the following:
https://www.youtube.com/c/thisisaviva