### PR TITLE
Rework of the channel url request structure and new performance flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,19 @@ import ytch from 'yt-channel-info'
 
 ## API
 
-**getChannelInfo(channelId)**
+**getChannelInfo(channelId, [channelIdType])**
 
 Returns information about a given channel ID.
+The optional argument 'channelIdType' can be provided to get faster results and less network requests if the type of channel id is known.
+- `0` = Default value used by the module. It will try all url types in the order channel -> user -> name
+- `1` = A channel id that is used with `https://www.youtube.com/channel/channelId` urls
+- `2` = A user id that is used with `https://www.youtube.com/user/channelId` urls
+- `3` = A name id that is used with `https://www.youtube.com/c/channelId` urls
 
 ```javascript
 const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
 
-ytch.getChannelInfo(channelId).then((response) => {
+ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    console.log(response)
 }).catch((err) => {
    console.log(err)
@@ -56,10 +61,11 @@ ytch.getChannelInfo(channelId).then((response) => {
    relatedChannels: Array[Object],
    allowedRegions: Array[String],
    isVerified: Boolean,
+   channelIdType: Number, 
 }
 ```
 
-**getChannelVideos(channelId, [sortBy])**
+**getChannelVideos(channelId, [sortBy], [channelIdType])**
 
 Grabs videos from a given channel ID.
 
@@ -67,11 +73,13 @@ Grabs videos from a given channel ID.
  - `oldest` - Grabs videos from a channel sorted by oldest videos
  - `popular` - Grabs videos from a channel sorted by the most popular (Highest amount of views)
 
+
+- `channelIdType` defined as for `getChannelInfo()`
  ```javascript
  const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
  const sortBy = 'newest'
 
-ytch.getChannelVideos(channelId, sortBy).then((response) => {
+ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
    console.log(response)
 }).catch((err) => {
    console.log(err)
@@ -80,7 +88,8 @@ ytch.getChannelVideos(channelId, sortBy).then((response) => {
  // Response object
  {
    items: Array[Object],
-   continuation: String // Will return null if no more results can be found.  Used with getChannelVideosMore()
+   continuation: String, // Will return null if no more results can be found.  Used with getChannelVideosMore()
+   channelIdType: Number,
  }
  ```
 
@@ -104,18 +113,21 @@ ytch.getChannelInfoMore(continuation).then((response) => {
  }
  ```
 
- **getChannelPlaylistInfo(channelId, [sortBy])**
+ **getChannelPlaylistInfo(channelId, [sortBy], [channelIdType])**
 
  Grabs playlist information of a given channel ID.
 
  - `last` - Grabs playlists from a channel sorted by the most recently updated playlist (Default option if none given)
  - `newest` - Grabs playlists from a channel sorted by the creation date (newest first)
 
-  ```javascript
+
+- `channelIdType` defined as for `getChannelInfo()` 
+  
+```javascript
 const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
 const sortBy = 'last'
 
-ytch.getChannelPlaylistInfo(channelId, sortBy).then((response) => {
+ytch.getChannelPlaylistInfo(channelId, sortBy, channelIdType).then((response) => {
    console.log(response)
 }).catch((err) => {
    console.log(err)
@@ -125,6 +137,7 @@ ytch.getChannelPlaylistInfo(channelId, sortBy).then((response) => {
  {
    items: Array[Object],
    continuation: String // Will return null if no more results can be found.  Used with getChannelPlaylistsMore()
+   channelIdType: Number,
  }
  ```
 
@@ -190,11 +203,12 @@ ytch.searchChannelMore(continuation).then((response) => {
  ```
 
 
-**getChannelCommunityPosts(channelId, authorURL)**
+**getChannelCommunityPosts(channelId, [channelIdType])**
 
-Searchs for all posts on the community page of a given channelId based on the given query.
-While the channelId is required as a fallback, a authorURL can be provided optionally to require one request to YouTube less.
-If the author URL fails, then it will fallback to the authorURL and try to access the page normally.
+Searches for all posts on the community page of a given channelId based on the given query.
+
+- `channelIdType` defined as for `getChannelInfo()`
+
 
   ```javascript
 const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
@@ -209,7 +223,8 @@ ytch.getChannelCommunityPosts(channelId, authorURL='http://www.youtube.com/c/cCh
  {
    items: Array[Object], // Described below
    continuation: String, // Will return null if no more results can be found.  Used with searchChannelMore()
-   innerTubeApi: String
+   innerTubeApi: String,
+   channelIdType: Number,
  }
  ```
 

--- a/app/fetchers/channel.js
+++ b/app/fetchers/channel.js
@@ -2,71 +2,22 @@ const helper = require('../helper')
 
 class YoutubeChannelFetcher {
   constructor(id, continuation) {
-    this._url = `https://youtube.com/channel/${id}/`
     this.continuation = continuation
   }
 
-  static async getChannelVideosNewest (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/videos?flow=grid&view=0&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/videos?flow=grid&view=0&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/videos?flow=grid&view=0&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await helper.parseChannelVideoResponse(channelPageResponse, channelId)
+  static async getChannelVideosNewest (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'videos?flow=grid&view=0&pbj=1', channelIdType)
+    return await helper.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
   }
 
-  static async getChannelVideosOldest (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/videos?view=0&sort=da&flow=grid&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/videos?view=0&sort=da&flow=grid&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/videos?view=0&sort=da&flow=grid&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await helper.parseChannelVideoResponse(channelPageResponse, channelId)
+  static async getChannelVideosOldest (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'videos?view=0&sort=da&flow=grid&pbj=1', channelIdType)
+    return await helper.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
   }
 
-  static async getChannelVideosPopular (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/videos?view=0&sort=p&flow=grid&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/videos?view=0&sort=p&flow=grid&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/videos?view=0&sort=p&flow=grid&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await helper.parseChannelVideoResponse(channelPageResponse, channelId)
+  static async getChannelVideosPopular (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'videos?view=0&sort=p&flow=grid&pbj=1', channelIdType)
+    return await helper.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
   }
 }
 

--- a/app/fetchers/playlist.js
+++ b/app/fetchers/playlist.js
@@ -6,70 +6,22 @@ class PlaylistFetcher {
     this.getOriginalURL = () => _url
   }
 
-  static async getChannelPlaylistLast (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/playlists?flow=grid&sort=lad&view=1&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/playlists?flow=grid&view=1&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/playlists?flow=grid&view=1&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await this.parseChannelPlaylistResponse(channelPageResponse)
+  static async getChannelPlaylistLast (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'playlists?flow=grid&sort=lad&view=1&pbj=1', channelIdType)
+    return await this.parseChannelPlaylistResponse(channelPageResponse.response, channelPageResponse.channelIdType)
   }
 
-  static async getChannelPlaylistOldest (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/playlists?view=1&sort=da&flow=grid&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/playlists?view=1&sort=da&flow=grid&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/playlists?view=1&sort=da&flow=grid&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await this.parseChannelPlaylistResponse(channelPageResponse)
+  static async getChannelPlaylistOldest (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'playlists?view=1&sort=da&flow=grid&pbj=1', channelIdType)
+    return await this.parseChannelPlaylistResponse(channelPageResponse.response, channelPageResponse.channelIdType)
   }
 
-  static async getChannelPlaylistNewest (channelId) {
-    const channelUrl = `https://youtube.com/channel/${channelId}/playlists?view=1&sort=dd&flow=grid&pbj=1`
-    let channelPageResponse = await helper.makeChannelRequest(channelUrl)
-
-    if (channelPageResponse.error) {
-      // Try again as a user channel
-      const userUrl = `https://youtube.com/user/${channelId}/playlists?view=1&sort=dd&flow=grid&pbj=1`
-      channelPageResponse = await helper.makeChannelRequest(userUrl)
-
-      if (channelPageResponse.error) {
-        const cUrl = `https://youtube.com/c/${channelId}/playlists?view=1&sort=dd&flow=grid&pbj=1`
-        channelPageResponse = await helper.makeChannelRequest(cUrl)
-        if (channelPageResponse.error) {
-          return Promise.reject(channelPageResponse.message)
-        }
-      }
-    }
-
-    return await this.parseChannelPlaylistResponse(channelPageResponse)
+  static async getChannelPlaylistNewest (channelId, channelIdType) {
+    const channelPageResponse = await helper.decideUrlRequestType(channelId, 'playlists?view=1&sort=dd&flow=grid&pbj=1', channelIdType)
+    return await this.parseChannelPlaylistResponse(channelPageResponse.response, channelPageResponse.channelIdType)
   }
 
-  static async parseChannelPlaylistResponse (response) {
+  static async parseChannelPlaylistResponse (response, channelIdType) {
     const channelMetaData = response.data[1].response.metadata.channelMetadataRenderer
     const channelName = channelMetaData.title
     const channelId = channelMetaData.externalId
@@ -110,7 +62,8 @@ class PlaylistFetcher {
 
     return {
       continuation: continuation,
-      items: playlistItems
+      items: playlistItems,
+      channelIdType: channelIdType,
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-channel-info",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Grab YouTube channel information without any official API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
---
Rework of the channel url request structure and new performance flag
---

The goals of the changes are the following:
- More compressed structure of channel URL request code
- Easier maintainability of network code
- Higher performance when newly provided flag is used

**More compressed structure of channel URL request code**

The code in the playlist.js and channel.js files have been reduced massively. The try and catch like testing of channelId URLs has been removed from the previous two and also from the YouTubeGrabber.js file. 

**Easier maintainability of network code**
For most of the functions, the function call to makeChannelRequest() has been moved into the helper class. So there are all URLs closely packed for easier maintainability. The functionality functions only provide the channelId, the appendix to the YouTube URL and the new channelIdType flag. 

**Higher performance when newly provided flag is used**
The new flag allows the user to specify what type of channelId it is. A channel id for /chanel/ URLs, a user id for /user/ URLs or a name id for /c/ URLs. That way the code can directly use the correct URL instead of trying all 3 in the worst case scenario. This boosts the performance massively due to less network requests and also less error checking. 

Additionally initital functionality function calls now return which type of channelId was provided if the testing was done, so if another request to the same channelId is made, the user can directly provide the flag out of the box.


