### PR TITLE
Added author field, fixed missing parts of the post's text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ The objects in the array of community posts all follow a basic structure but var
   ```javascript
 postData = {
   postText: String,
-  postId: String,
+  postId: String, 
+  author: String,
   authorThumbnails: Array[Object], // Array of objects with links to images
   publishedText: String,
   voteCount: String,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-channel-info",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Grab YouTube channel information without any official API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added a new field 'author' to the community posts, so it can be displayed which channel actually posted the post.
Additionally I now concatenate all strings of the post's text together instead of only using the first part if split.
Additionally added case for very rare shared posts, which only occurred on the YouTube Creator channel yet, but must be covered, else the module fails