### PR TITLE
add channel tags to channel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    },
    allowedRegions: Array[String],
    isVerified: Boolean,
+   tags: Array[String],
    channelIdType: Number, 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    },
    allowedRegions: Array[String],
    isVerified: Boolean,
-   tags: Array[String],
+   tags: Array[String], // Will return null if none exist
    channelIdType: Number, 
 }
 ```

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -114,12 +114,9 @@ class YoutubeGrabber {
     if (channelHeaderData.badges) {
       isVerified = channelHeaderData.badges.some((badge) => badge.metadataBadgeRenderer.tooltip === 'Verified')
     }
-    let tags = null
 
-    if (typeof (channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags) !== 'undefined') {
-      tags = channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags
-    }
-  
+    const tags = channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags || null
+
     const channelInfo = {
       author: channelMetaData.title,
       authorId: channelMetaData.externalId,

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -114,13 +114,12 @@ class YoutubeGrabber {
     if (channelHeaderData.badges) {
       isVerified = channelHeaderData.badges.some((badge) => badge.metadataBadgeRenderer.tooltip === 'Verified')
     }
-    let tags=null;
-    try {
+    let tags = null
+
+    if (typeof (channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags) !== 'undefined') {
       tags = channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags
-    } catch (error) {
-      console.error(error);
     }
-    
+  
     const channelInfo = {
       author: channelMetaData.title,
       authorId: channelMetaData.externalId,

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -114,7 +114,13 @@ class YoutubeGrabber {
     if (channelHeaderData.badges) {
       isVerified = channelHeaderData.badges.some((badge) => badge.metadataBadgeRenderer.tooltip === 'Verified')
     }
-
+    let tags=null;
+    try {
+      tags = channelPageResponse.data[1].response.microformat.microformatDataRenderer.tags
+    } catch (error) {
+      console.error(error);
+    }
+    
     const channelInfo = {
       author: channelMetaData.title,
       authorId: channelMetaData.externalId,
@@ -131,6 +137,7 @@ class YoutubeGrabber {
       },
       allowedRegions: channelMetaData.availableCountryCodes,
       isVerified: isVerified,
+      tags: tags,
       channelIdType: decideResponse.channelIdType,
     }
 


### PR DESCRIPTION
Because Channel tags aren't something that is displayed to users on YouTube, I imagine it's more likely to change than other properties so I surrounded it in a try catch loop.

This is what the output looks like when running getChannelInfo on Linus Tech Tips

![image](https://user-images.githubusercontent.com/78101139/119932034-8aafd480-bf50-11eb-86dc-e2151bc936d6.png)
