### PR TITLE
[Fix] channel video preview breaks with some premium videos

### DIFF
--- a/app/helper.js
+++ b/app/helper.js
@@ -134,7 +134,7 @@ class YoutubeGrabberHelper {
       publishedText = premiereDate.toLocaleString()
     } else if (typeof (video.viewCountText) === 'undefined') {
       premium = true
-      publishedText = video.publishedTimeText.simpleText
+	  publishedText = video.publishedTimeText ? video.publishedTimeText.simpleText : undefined
       durationText = 'PREMIERE'
       viewCount = 0
       viewCountText = '0 views'


### PR DESCRIPTION
---
[Fix] fix channel video preview with premium videos
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1534

**Description**
Fixes the video preview of a channel that contains specific premium videos. This issue does not happen with all premium videos. But it happens for this channel:
https://www.youtube.com/user/Vsauce3/videos
This is one of the videos that causes an issue:
https://www.youtube.com/watch?v=17wyfuhKt2c

**Screenshot of the issue**
![image](https://user-images.githubusercontent.com/67011163/126711514-9844e14e-63be-4b84-abb4-bcd7868505c6.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes. 

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 1.3.2