### PR TITLE
Returning an object instead of error on non-existing channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ The optional argument 'channelIdType' can be provided to get faster results and 
 const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
 
 ytch.getChannelInfo(channelId, channelIdType).then((response) => {
-   console.log(response)
+   if (!response.alert) {
+      console.log(response)
+   } else {
+      console.log('Channel could not be found.')
+      // throw response.alert
+   }
 }).catch((err) => {
    console.log(err)
 })
@@ -66,6 +71,7 @@ ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    isVerified: Boolean,
    tags: Array[String], // Will return null if none exist
    channelIdType: Number, 
+   alert: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
 }
 ```
 
@@ -84,7 +90,12 @@ Grabs videos from a given channel ID.
  const sortBy = 'newest'
 
 ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
-   console.log(response)
+   if (!response.alert) {
+      console.log(response)
+   } else {
+      console.log('Channel could not be found.')
+      // throw response.alert
+   }
 }).catch((err) => {
    console.log(err)
 })
@@ -94,6 +105,7 @@ ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
    items: Array[Object],
    continuation: String, // Will return null if no more results can be found.  Used with getChannelVideosMore()
    channelIdType: Number,
+   alert: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
  }
  ```
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The optional argument 'channelIdType' can be provided to get faster results and 
 const channelId = 'UCXuqSBlHAE6Xw-yeJA0Tunw'
 
 ytch.getChannelInfo(channelId, channelIdType).then((response) => {
-   if (!response.alert) {
+   if (!response.alertMessage) {
       console.log(response)
    } else {
       console.log('Channel could not be found.')
-      // throw response.alert
+      // throw response.alertMessage
    }
 }).catch((err) => {
    console.log(err)
@@ -71,7 +71,7 @@ ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    isVerified: Boolean,
    tags: Array[String], // Will return null if none exist
    channelIdType: Number, 
-   alert: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
+   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
 }
 ```
 
@@ -90,11 +90,11 @@ Grabs videos from a given channel ID.
  const sortBy = 'newest'
 
 ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
-   if (!response.alert) {
+   if (!response.alertMessage) {
       console.log(response)
    } else {
       console.log('Channel could not be found.')
-      // throw response.alert
+      // throw response.alertMessage
    }
 }).catch((err) => {
    console.log(err)
@@ -105,7 +105,7 @@ ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
    items: Array[Object],
    continuation: String, // Will return null if no more results can be found.  Used with getChannelVideosMore()
    channelIdType: Number,
-   alert: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
+   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
  }
  ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ytch.getChannelInfo(channelId, channelIdType).then((response) => {
    isVerified: Boolean,
    tags: Array[String], // Will return null if none exist
    channelIdType: Number, 
-   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
+   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise undefined
 }
 ```
 
@@ -105,7 +105,7 @@ ytch.getChannelVideos(channelId, sortBy, channelIdType).then((response) => {
    items: Array[Object],
    continuation: String, // Will return null if no more results can be found.  Used with getChannelVideosMore()
    channelIdType: Number,
-   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise null
+   alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise undefined 
  }
  ```
 

--- a/app/helper.js
+++ b/app/helper.js
@@ -59,7 +59,7 @@ class YoutubeGrabberHelper {
   async parseChannelVideoResponse(response, channelId, channelIdType) {
     if (typeof (response.data[1].response.alerts) !== 'undefined') {
       return {
-        alert: response.data[1].response.alerts[0].alertRenderer.text.simpleText
+        alertMessage: response.data[1].response.alerts[0].alertRenderer.text.simpleText
       }
     }
 

--- a/app/helper.js
+++ b/app/helper.js
@@ -57,6 +57,12 @@ class YoutubeGrabberHelper {
   }
 
   async parseChannelVideoResponse(response, channelId, channelIdType) {
+    if (typeof (response.data[1].response.alerts) !== 'undefined') {
+      return {
+        alert: response.data[1].response.alerts[0].alertRenderer.text.simpleText
+      }
+    }
+
     const channelMetaData = response.data[1].response.metadata.channelMetadataRenderer
     const channelName = channelMetaData.title
     const channelVideoData = response.data[1].response.contents.twoColumnBrowseResultsRenderer.tabs[1].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -17,8 +17,9 @@ class YoutubeGrabber {
     const channelPageResponse = decideResponse.response
 
     if (typeof (channelPageResponse.data[1].response.alerts) !== 'undefined') {
-      const alert = channelPageResponse.data[1].response.alerts[0].alertRenderer.text.simpleText
-      return Promise.reject(alert)
+      return {
+        alert: response.data[1].response.alerts[0].alertRenderer.text.simpleText
+      }
     }
 
     const channelMetaData = channelPageResponse.data[1].response.metadata.channelMetadataRenderer

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -18,7 +18,7 @@ class YoutubeGrabber {
 
     if (typeof (channelPageResponse.data[1].response.alerts) !== 'undefined') {
       return {
-        alert: response.data[1].response.alerts[0].alertRenderer.text.simpleText
+        alert: channelPageResponse.data[1].response.alerts[0].alertRenderer.text.simpleText
       }
     }
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -18,7 +18,7 @@ class YoutubeGrabber {
 
     if (typeof (channelPageResponse.data[1].response.alerts) !== 'undefined') {
       return {
-        alert: channelPageResponse.data[1].response.alerts[0].alertRenderer.text.simpleText
+        alertMessage: channelPageResponse.data[1].response.alerts[0].alertRenderer.text.simpleText
       }
     }
 


### PR DESCRIPTION
**Relevant issue**
closes #33

**Description**
The functions `getChannelInfo` and `getChannelVideos` will now return the alert message given by a response as the sole property of the return object upon loading a non-existent (e.g., removed, banned) channel. Formerly, `getChannelInfo` threw a rejected Promise object with the response alert text, and `getChannelVideos` did not check for this case at all (thus, it annoyingly returned `TypeError: Cannot read property 'channelMetadataRenderer' of undefined`). The README is updated accordingly with the new usage of the aforementioned functions (as well as the commented-out `throw response.alert` which informs developers how to maintain the old error design flow).

This PR should now handle the common case of a deleted or banned channel (or attempting to load the videos of such a channel) more elegantly. Here are three reasons for this design in the words of @GilgusMaximus:
> 
> - Other package users can check the documentation on what a status code means more easily than long exceptions
> - If we leave in an exception, we can't tell whether it is a new bug or an old bug
> - Exception handling makes code more complex + less easy to read and therefore can be abstracted by the module to avoid it in the main code base
