### PR TITLE
Add getChannelStats method

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ ytch.getChannelCommunityPosts(payload).then((response) => {
 Gets the stats of a channel
 - payload (Object) (Required) - An object containing the various options
   - channelId (String) (Required) - The channel ID to get stats from
-  - channelIdType (Integer) (Optional) - defined as for `getChannelInfo()`
+  - channelIdType (Integer) (Optional) - Same definition as `channelIdType` in `getChannelInfo()`
   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
 
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,34 @@ ytch.getChannelCommunityPosts(payload).then((response) => {
  }
  ```
 
+ **getChannelStats(payload)**
+
+Gets the stats of a channel
+- payload (Object) (Required) - An object containing the various options
+  - channelId (String) (Required) - The channel ID to get stats from
+  - channelIdType (Integer) (Optional) - defined as for `getChannelInfo()`
+  - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+
+
+```javascript
+const payload = {
+   channelId: 'UCXuqSBlHAE6Xw-yeJA0Tunw'
+}
+
+ytch.getChannelStats(payload).then((response) => {
+   console.log(response)
+}).catch((err) => {
+   console.log(err)
+})
+
+ // Response object
+ {
+   joined: Integer, // Date joined in ms
+   viewCount: Integer, // Total views on channel
+   location: String // location of channel
+ }
+ ```
+
 **getChannelCommunityPostsMore(payload)**
 
 Grabs more search results within a channel community page.  Uses the continuation and innerTubeApi strings returned from `getChannelCommunityPosts()` or from past calls to `getChannelCommunityPostsMore()`.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Grabs videos from a given channel ID.
     - `newest` - Grabs videos from a channel sorted by newest / most recently uploaded (Default option if none given)
     - `oldest`- Grabs videos from a channel sorted by oldest videos
     - `popular` - Grabs videos from a channel sorted by the most popular (Highest amount of views)
-  - channelIdType (Integer) (Optional) - defined as for `getChannelInfo()`
-  - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+  - channelIdType (Integer) (Optional) - Same definition as 'channelIdType' in `getChannelInfo()`
+  - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
 
  ```javascript
  const payload = {
@@ -127,7 +127,7 @@ ytch.getChannelVideos(payload).then((response) => {
 Grabs videos from a given channel ID.
 - payload (Object) (Required) - An object containing the various options
   - continuation (String) (Required) - The continuation string from `getChannelVideos()` or from past calls to `getChannelVideosMore()`.
-  - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+  - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in  `getChannelInfo()`
 
 
  ```javascript
@@ -156,8 +156,8 @@ ytch.getChannelVideosMore(payload).then((response) => {
    - sortBy (String) (Optional) - 'last' sort by last updated or 'newest' sort by creation date
       - `last` - Grabs playlists from a channel sorted by the most recently updated playlist (Default option if none given)
       - `newest` - Grabs playlists from a channel sorted by the creation date (newest first)
-   - httpsAgent (Object) (Optional) - defined as for `getChannelInfo()`
-   - channelIdType (Integer) (Optional) - defined as for `getChannelInfo()` 
+   - httpsAgent (Object) (Optional) - Same definition as 'httpsAgent' in `getChannelInfo()`
+   - channelIdType (Integer) (Optional) - Same definition as 'channelIdType' in `getChannelInfo()` 
 
 ```javascript
 const payload = {
@@ -184,7 +184,7 @@ ytch.getChannelPlaylistInfo(payload).then((response) => {
  Grabs more playlists within a channel.  Uses the continuation string returned from `getChannelPlaylists()` or from past calls to `getChannelPlaylistsMore()`.
  - payload (Object) (Required) - An object containing the various options
    - continuation (String) (Required) - The continuation string from `getChannelPlaylists()` or from past calls to `getChannelPlaylistsMore()`.
-   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+   - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
 
 ```javascript
 const payload = {
@@ -210,7 +210,7 @@ ytch.getChannelPlaylistsMore(payload).then((response) => {
  - payload (Object) (Required) - An object containing the various options
    - channelId (String) (Required) - The channel you want to search
    - query (String) (Required) - The query you want to use
-   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+   - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
   
 ```javascript
 const payload = {
@@ -236,7 +236,7 @@ ytch.searchChannel(payload).then((response) => {
  Grabs more search results within a channel.  Uses the continuation string returned from `searchChannel()` or from past calls to `searchChannelMore()`.
  - payload (Object) (Required) - An object containing the various options
    - continuation (String) (Required) - The continuation string from `searchChannel()` or from past calls to `searchChannelMore()`.
-   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+   - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
 
 ```javascript
 const payload = {
@@ -261,7 +261,7 @@ ytch.searchChannelMore(payload).then((response) => {
  Grabs more related channels within a channel.  Uses the relatedChannelsContinuation string returned from `getChannelInfo()` or from past calls to `getRelatedChannelsMore()`.
  - payload (Object) (Required) - An object containing the various options
    - continuation (String) (Required) - The continuation string from `getChannelInfo()` or from past calls to `getRelatedChannelsMore()`.
-   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+   - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
   
 ```javascript
  const payload = {
@@ -287,8 +287,8 @@ Searches for all posts on the community page of a given channelId based on the g
 
 - payload (Object) (Required) - An object containing the various options
   - channelId (String) (Required) - The channel ID to get community posts from
-  - channelIdType (Integer) (Optional) - defined as for `getChannelInfo()`
-  - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+  - channelIdType (Integer) (Optional) - Same definition as 'channelIdType' for `getChannelInfo()`
+  - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
 
 
 ```javascript
@@ -317,7 +317,7 @@ Gets the stats of a channel
 - payload (Object) (Required) - An object containing the various options
   - channelId (String) (Required) - The channel ID to get stats from
   - channelIdType (Integer) (Optional) - Same definition as `channelIdType` in `getChannelInfo()`
-  - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+  - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
 
 
 ```javascript
@@ -345,7 +345,7 @@ Grabs more search results within a channel community page.  Uses the continuatio
 - payload (Object) (Required) - An object containing the various options
    - continuation (String) (Required) - The continuation string from `getChannelCommunityPosts()` or from past calls to `getChannelCommunityPostsMore()`.
    - innterTubeApi (String) (Required) - The innerTubeApi string from `getChannelCommunityPosts()` or from past calls to `getChannelCommunityPostsMore()`.
-   - httpsAgent (Object) (Optional) -  defined as for `getChannelInfo()`
+   - httpsAgent (Object) (Optional) -  Same definition as 'httpsAgent' in `getChannelInfo()`
   
 ```javascript
 const payload = {

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ ytch.getChannelStats(payload).then((response) => {
 
  // Response object
  {
-   joined: Integer, // Date joined in ms
+   joinedDate: Integer, // Date joined in ms
    viewCount: Integer, // Total views on channel
    location: String // location of channel
  }

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -516,6 +516,32 @@ class YoutubeGrabber {
     const contValue = ('continuationItemRenderer' in postDataArray[postDataArray.length - 1]) ? postDataArray[postDataArray.length - 1].continuationItemRenderer.continuationEndpoint.continuationCommand.token : null
     return { items: ytGrabHelp.createCommunityPostArray(postDataArray), continuation: contValue, innerTubeApi: innerAPIKey }
   }
+
+  static async getChannelStats(payload) {
+    const channelId = payload.channelId
+    const channelIdType = payload.channelIdType ?? 0
+    const httpAgent = payload.httpAgent ?? null
+
+    const ytGrabHelp = YoutubeGrabberHelper.create(httpAgent)
+    const decideResponse = await ytGrabHelp.decideUrlRequestType(channelId, 'about?flow=grid&view=0&pbj=1', channelIdType)
+    const channelPageResponse = decideResponse.response
+    const headerTabs = channelPageResponse.data[1].response.contents.twoColumnBrowseResultsRenderer.tabs
+    const aboutTab = headerTabs.filter((data) => {
+      if (typeof data.tabRenderer !== 'undefined') {
+        return data.tabRenderer.title === 'About'
+      }
+      return false
+    })[0]
+    const contents = aboutTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0]
+    const joined = Date.parse(contents.channelAboutFullMetadataRenderer.joinedDateText.runs[1].text)
+    const views = contents.channelAboutFullMetadataRenderer.viewCountText.simpleText.replace(/\D/g, '')
+    const location = contents.channelAboutFullMetadataRenderer.country.simpleText
+    return {
+      joinedDate: joined,
+      viewCount: parseInt(views),
+      location: location
+    }
+  }
 }
 
 module.exports = YoutubeGrabber


### PR DESCRIPTION
Extracts the following

- Channel Join Date
- Channel View Count
- Channel Location

Related issue: https://github.com/FreeTubeApp/FreeTube/issues/1357

I'm not sure if these stats can be hidden or not so I have not tested this method with a channel that has it hidden (as I am not aware of any/if it's possible)


I also think that the items from this method make sense as being a part of getChannelInfo but I decided not to do it because I imagine a lot of people won't use it and it would add an extra http request to YT