### PR TITLE
revert changes from #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ ytch.getChannelVideos(payload).then((response) => {
    items: Array[Object],
    continuation: String, // Will return null if no more results can be found.  Used with getChannelVideosMore()
    channelIdType: Number,
-   playlistUrl: String, // The url to the channel playlist for "Play all videos"
    alertMessage: String, // Will return a response alert message if any (e.g., "This channel does not exist."). Otherwise undefined 
  }
  ```

--- a/app/helper.js
+++ b/app/helper.js
@@ -72,8 +72,7 @@ class YoutubeGrabberHelper {
       // Channel has no videos
       return {
         items: [],
-        continuation: null,
-        playlistUrl: null
+        continuation: null
       }
     }
 
@@ -97,18 +96,11 @@ class YoutubeGrabberHelper {
     }).map((item) => {
       return this.parseVideo(item, channelInfo)
     })
-    const channelSubMenuRenderer = response.data[1].response.contents.twoColumnBrowseResultsRenderer.tabs[1].tabRenderer.content.sectionListRenderer.subMenu.channelSubMenuRenderer
-    let playlistUrl = null
-    if ('playAllButton' in channelSubMenuRenderer) {
-      const playlistId = channelSubMenuRenderer.playAllButton.buttonRenderer.navigationEndpoint.watchPlaylistEndpoint.playlistId
-      playlistUrl = `https://www.youtube.com/watch?v=${latestVideos[0].videoId}&list=${playlistId}`
-    }
 
     return {
       items: latestVideos,
       continuation: continuation,
-      channelIdType: channelIdType,
-      playlistUrl: playlistUrl
+      channelIdType: channelIdType
     }
   }
 


### PR DESCRIPTION
youtube stopped providing the url for "Play all" in the videos tab.
Getting the "Uploads" playlist from #55 will be the way to get a playlist of all videos from the channel.