### PR TITLE
Adjust parsing of channel page

### DIFF
--- a/app/helper.js
+++ b/app/helper.js
@@ -73,8 +73,8 @@ class YoutubeGrabberHelper {
     const videoTab = YoutubeGrabberHelper.findTab(channelPageDataResponse.contents.twoColumnBrowseResultsRenderer.tabs)
 
     let channelVideoData
-    if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
-      channelVideoData = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer
+    if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
+      channelVideoData = { items: videoTab.tabRenderer.content.richGridRenderer.contents }
     }
     if (typeof (channelVideoData) === 'undefined') {
       // Channel has no videos
@@ -181,8 +181,9 @@ class YoutubeGrabberHelper {
     let lengthSeconds = 0
     let durationText
     let publishedText = ''
-
-    if (typeof (obj.gridVideoRenderer) === 'undefined' && typeof (obj.videoRenderer) !== 'undefined') {
+    if (typeof (obj.richItemRenderer) !== 'undefined') {
+      video = obj.richItemRenderer.content.videoRenderer
+    } else if (typeof (obj.gridVideoRenderer) === 'undefined' && typeof (obj.videoRenderer) !== 'undefined') {
       video = obj.videoRenderer
     } else if (typeof (obj.gridVideoRenderer) !== 'undefined') {
       video = obj.gridVideoRenderer

--- a/app/helper.js
+++ b/app/helper.js
@@ -75,6 +75,8 @@ class YoutubeGrabberHelper {
     let channelVideoData
     if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
       channelVideoData = { items: videoTab.tabRenderer.content.richGridRenderer.contents }
+    } else if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
+      channelVideoData = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer
     }
     if (typeof (channelVideoData) === 'undefined') {
       // Channel has no videos

--- a/app/helper.js
+++ b/app/helper.js
@@ -183,6 +183,7 @@ class YoutubeGrabberHelper {
     let publishedText = ''
     if (typeof (obj.richItemRenderer) !== 'undefined') {
       video = obj.richItemRenderer.content.videoRenderer
+      video.lengthSeconds = video.lengthText.simpleText.split(':').reduce((acc,time) => (60 * acc) + +time)
     } else if (typeof (obj.gridVideoRenderer) === 'undefined' && typeof (obj.videoRenderer) !== 'undefined') {
       video = obj.videoRenderer
     } else if (typeof (obj.gridVideoRenderer) !== 'undefined') {

--- a/app/helper.js
+++ b/app/helper.js
@@ -321,7 +321,7 @@ class YoutubeGrabberHelper {
     const communityTab = YoutubeGrabberHelper.findTab(contentDataJSON.contents.twoColumnBrowseResultsRenderer.tabs)
 
     if (communityTab) {
-      contentDataJSON = contentDataJSON.contents.twoColumnBrowseResultsRenderer.tabs[3].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer
+      contentDataJSON = contentDataJSON.contents.twoColumnBrowseResultsRenderer.tabs.find((tab) => tab.tabRenderer?.title === "Community").tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer
       if ('continuationItemRenderer' in contentDataJSON.contents[contentDataJSON.contents.length - 1]) {
         return { items: this.createCommunityPostArray(contentDataJSON.contents), continuation: contentDataJSON.contents[contentDataJSON.contents.length - 1].continuationItemRenderer.continuationEndpoint.continuationCommand.token, innerTubeApi: innertubeAPIkey, channelIdType: channelIdType }
       }

--- a/app/helper.js
+++ b/app/helper.js
@@ -188,9 +188,9 @@ class YoutubeGrabberHelper {
     let publishedText = ''
     if (typeof (obj.richItemRenderer) !== 'undefined') {
       video = obj.richItemRenderer.content.videoRenderer
-      video.lengthSeconds = video.lengthText.simpleText.split(':').reduce((acc,time) => (60 * acc) + +time)
+      video.lengthSeconds = video.lengthText.simpleText.split(':').reduce((acc, time) => (60 * acc) + +time)
       video.title.simpleText = video.title.runs.at(0)
-    } else if (typeof(obj.reelItemRenderer) !== 'undefined') {
+    } else if (typeof (obj.reelItemRenderer) !== 'undefined') {
       video = obj.reelItemRenderer
       video.title = video.headline
       video.publishedTimeText = { simpleText: '' }

--- a/app/helper.js
+++ b/app/helper.js
@@ -321,7 +321,7 @@ class YoutubeGrabberHelper {
     const communityTab = YoutubeGrabberHelper.findTab(contentDataJSON.contents.twoColumnBrowseResultsRenderer.tabs)
 
     if (communityTab) {
-      contentDataJSON = contentDataJSON.contents.twoColumnBrowseResultsRenderer.tabs.find((tab) => tab.tabRenderer?.title === "Community").tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer
+      contentDataJSON = communityTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer
       if ('continuationItemRenderer' in contentDataJSON.contents[contentDataJSON.contents.length - 1]) {
         return { items: this.createCommunityPostArray(contentDataJSON.contents), continuation: contentDataJSON.contents[contentDataJSON.contents.length - 1].continuationItemRenderer.continuationEndpoint.continuationCommand.token, innerTubeApi: innertubeAPIkey, channelIdType: channelIdType }
       }


### PR DESCRIPTION
# Adjust parsing of channel page to keep in line with YouTube layout updates

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
FreeTubeApp/FreeTube#2784

## Description
The YT page that channel videos are extracted from has changed its layout, and this is causing `parseChannelVideoResponse` to not return any videos. Also, the community tab isn't always the 4th tab anymore, and this can cause errors. This PR aims to fix these things by updating the way that page is parsed.

## Screenshots <!-- If appropriate -->
_before:_
<img src="https://user-images.githubusercontent.com/106682128/199164228-5ab00a57-bc7c-4a82-863d-224dae3be7cc.png" width="400" />
_after:_
<img src="https://user-images.githubusercontent.com/106682128/199164510-dcc3cf68-a1b1-4ae8-8f91-6422ccfca972.png" width="400" />

## Additional context
I assume this layout change was A-B tested because these issues occurred sporadically until recently. 

Some users in the freetube matrix channel had discussed how they were able to change their backend preference to Invidious in order to solve this issue, but it seems that this issue is also effecting Invidious now (EX: https://invidious.namazso.eu/channel/UCXuqSBlHAE6Xw-yeJA0Tunw doesn't display any videos).

I ran the automated tests, and the only issue I ran into was with `shorts` missing their `lengthSeconds`. It doesn't seem like the `reelItemRenderer` displays the length of the video, so I am unsure what to do about this:
<img src="https://user-images.githubusercontent.com/106682128/199184861-6cd03357-938e-4d52-b26c-3d0506f8e63e.png" width="400" />