### PR TITLE
Adjust parsing of channel page continuation

### DIFF
--- a/app/helper.js
+++ b/app/helper.js
@@ -189,7 +189,7 @@ class YoutubeGrabberHelper {
     if (typeof (obj.richItemRenderer) !== 'undefined') {
       video = obj.richItemRenderer.content.videoRenderer
       video.lengthSeconds = video.lengthText.simpleText.split(':').reduce((acc, time) => (60 * acc) + +time)
-      video.title.simpleText = video.title.runs.at(0)
+      video.title.simpleText = video.title.runs.at(0).text
     } else if (typeof (obj.reelItemRenderer) !== 'undefined') {
       video = obj.reelItemRenderer
       video.title = video.headline

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -247,13 +247,24 @@ class YoutubeGrabber {
       nextContinuation = continuationItem[0].continuationItemRenderer.continuationEndpoint.continuationCommand.token
     }
 
-    const channelMetaData = channelPageResponse.data.metadata.channelMetadataRenderer
-    const channelName = channelMetaData.title
-    const channelId = channelMetaData.externalId
+    const channelMetaData = channelPageResponse.data?.metadata?.channelMetadataRenderer
+    let channelInfo = {}
+    if (channelMetaData) {
+      const channelName = channelMetaData.title
+      const channelId = channelMetaData.externalId
 
-    const channelInfo = {
-      channelId: channelId,
-      channelName: channelName
+      channelInfo = {
+        channelId,
+        channelName
+      }
+    } else {
+      const firstVideoTitle = continuationData[0].richItemRenderer.content.videoRenderer.title
+      const firstPublishTimeText = continuationData[0].richItemRenderer.content.videoRenderer.publishedTimeText
+
+      channelInfo = {
+        channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === "GOOGLE_HELP").params[0].value,
+        channelName: new RegExp(`${firstVideoTitle.runs[0].text} by (.*?) ${firstPublishTimeText.simpleText}`, 'g').exec(firstVideoTitle.accessibility.accessibilityData.label)[1]
+      }
     }
 
     const nextVideos = continuationData.filter((item) => {

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -262,7 +262,7 @@ class YoutubeGrabber {
       const firstPublishTimeText = continuationData[0].richItemRenderer.content.videoRenderer.publishedTimeText
 
       channelInfo = {
-        channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === "GOOGLE_HELP").params[0].value,
+        channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === 'GOOGLE_HELP').params[0].value,
         channelName: new RegExp(`${firstVideoTitle.runs[0].text} by (.*?) ${firstPublishTimeText.simpleText}`, 'g').exec(firstVideoTitle.accessibility.accessibilityData.label)[1]
       }
     }


### PR DESCRIPTION
# Adjust parsing of channel page continuation

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to FreeTubeApp/yt-channel-info#113

## Description
The video titles coming from `richItemRenderer` is missing the `.text` property, and the result is that `videoTitle` is an object instead of a string. Also, the `channelId` and `channelName` seem to have moved in channel continuations, so this PR maps that data in order to prevent `getChannelVideosMore` from throwing.

## Screenshots <!-- If appropriate -->
_before:_
![before](https://user-images.githubusercontent.com/106682128/199261453-2ac1ca91-3ccc-446b-b3e8-a82e7ec66d93.gif)
_after:_
![after](https://user-images.githubusercontent.com/106682128/199261489-da4c36f0-8dcd-42bf-b46d-6e6a765af369.gif)

