### PR TITLE
Adjust regex to be more resilient

### DIFF
--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -263,7 +263,7 @@ class YoutubeGrabber {
 
       channelInfo = {
         channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === 'GOOGLE_HELP').params[0].value,
-        channelName: new RegExp(`${firstVideoTitle.runs[0].text} by (.*?) ${firstPublishTimeText.simpleText}`, 'g').exec(firstVideoTitle.accessibility.accessibilityData.label)[1]
+        channelName: new RegExp(`${firstVideoTitle.runs[0].text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} by (.*?) ${firstPublishTimeText.simpleText}`, 'g').exec(firstVideoTitle.accessibility.accessibilityData.label)[1]
       }
     }
 

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -258,12 +258,19 @@ class YoutubeGrabber {
         channelName
       }
     } else {
-      const firstVideoTitle = continuationData[0].richItemRenderer.content.videoRenderer.title
-      const firstPublishTimeText = continuationData[0].richItemRenderer.content.videoRenderer.publishedTimeText
-
-      channelInfo = {
-        channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === 'GOOGLE_HELP').params[0].value,
-        channelName: new RegExp(`${firstVideoTitle.runs[0].text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} by (.*?) ${firstPublishTimeText.simpleText}`, 'g').exec(firstVideoTitle.accessibility.accessibilityData.label)[1]
+      let i = 0
+      // Look through every video until you can successfully find the channel metadata
+      while (channelInfo.channelName === undefined && i < continuationData.length - 1) {
+        const videoTitle = continuationData[i].richItemRenderer.content.videoRenderer.title
+        const publishTimeText = continuationData[i].richItemRenderer.content.videoRenderer.publishedTimeText
+        channelInfo = {
+          channelId: channelPageResponse.data.responseContext.serviceTrackingParams.find((service) => service.service === 'GOOGLE_HELP').params[0].value
+        }
+        const channelNameRegex = new RegExp(`${videoTitle.runs[0].text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} by (.*?) ${publishTimeText.simpleText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'g').exec(videoTitle.accessibility.accessibilityData.label)
+        if (channelNameRegex !== null && channelNameRegex.length > 1) {
+          channelInfo.channelName = channelNameRegex[1]
+        }
+        i++
       }
     }
 


### PR DESCRIPTION
# Adjust regex to be more resilient

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to FreeTubeApp/yt-channel-info#115
Closes FreeTubeApp/yt-channel-info#118

## Description
I just realized that the regular expression used for finding channel names uses strings pulled from the YT response without sanitizing them first, and this will mean that any video with a symbol in the title could cause unexpected behavior. Vsauce is a really good example of this because they have lots of videos with weird symbols in the titles (EX: "mí͇͔̠śtk̥̞àẹ̶̢̪s "). I also added a loop to increase the likelihood that the channel name will be able to be successfully retrieved in channel page continuations.

If absolutely none of the videos in the continuation contain accessibility data which can be parsed, it still won't throw, but it will pass back the `channelName` as undefined. In FreeTube, this should just mean the `channelName` won't display at all under the video which isn't the best thing in the world, but it is still better than simply throwing in the case of a catastrophic failure.

## Screenshots <!-- If appropriate -->
_before:_
![before](https://user-images.githubusercontent.com/106682128/199405243-9d8ec353-c50a-4d27-8f25-ba839f407773.gif)
_after:_
![after](https://user-images.githubusercontent.com/106682128/199405261-6ca3bb8f-649a-4e26-bcd2-25fbc58b79f1.gif)

