### PR TITLE
Restore check for `sectionListRender`

### DIFF
--- a/app/helper.js
+++ b/app/helper.js
@@ -73,14 +73,15 @@ class YoutubeGrabberHelper {
     const videoTab = YoutubeGrabberHelper.findTab(channelPageDataResponse.contents.twoColumnBrowseResultsRenderer.tabs)
 
     let channelVideoData
-    if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
-      channelVideoData = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer
-    } else if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
+    if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
       channelVideoData = { items: videoTab.tabRenderer.content.richGridRenderer.contents }
     } else if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
       const contents = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0]
       if ('reelShelfRenderer' in contents) {
         channelVideoData = contents.reelShelfRenderer
+      }
+      if ('gridRenderer' in contents) {
+        channelVideoData = contents.gridRenderer
       }
     }
     if (typeof (channelVideoData) === 'undefined') {

--- a/app/helper.js
+++ b/app/helper.js
@@ -73,7 +73,9 @@ class YoutubeGrabberHelper {
     const videoTab = YoutubeGrabberHelper.findTab(channelPageDataResponse.contents.twoColumnBrowseResultsRenderer.tabs)
 
     let channelVideoData
-    if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
+    if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
+      channelVideoData = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer
+    } else if (videoTab && 'richGridRenderer' in videoTab.tabRenderer.content) {
       channelVideoData = { items: videoTab.tabRenderer.content.richGridRenderer.contents }
     } else if (videoTab && 'sectionListRenderer' in videoTab.tabRenderer.content) {
       const contents = videoTab.tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0]

--- a/test/channelVideos.test.js
+++ b/test/channelVideos.test.js
@@ -37,6 +37,13 @@ describe('Getting channel videos', () => {
     })
   })
 
+  test('Music Channel', () => {
+    const parameters = { channelId: 'UCZU9T1ceaOgwfLRq7OKFU4Q', channelIdType: 1 }
+    return ytch.getChannelVideos(parameters).then((data) => {
+      expect(data.items.length).not.toBe(0)
+    })
+  })
+
   test('Public channel w/o videos', () => {
     const parameters = { channelId: 'UCS-DgEvT4XuQsrrmI7iZVsA', channelIdType: 1 }
     return ytch.getChannelVideos(parameters).then((data) => {

--- a/test/channelVideos.test.js
+++ b/test/channelVideos.test.js
@@ -33,7 +33,7 @@ describe('Getting channel videos', () => {
   test('Shorts Channel', () => {
     const parameters = { channelId: 'UC4-79UOlP48-QNGgCko5p2g', channelIdType: 1 }
     return ytch.getChannelVideos(parameters).then((data) => {
-      expect(data.items[0].lengthSeconds).not.toBe(0)
+      expect(data.items.length).not.toBe(0)
     })
   })
 


### PR DESCRIPTION
# Restore check for `sectionListRender`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
Music channels such as [Infected Mushroom](https://www.youtube.com/channel/UCrbvoMC0zUvPL8vjswhLOSw) still use the `gridRenderer` to display their content, and as a result, `yt-channel-info` is returning no videos for these channels. This PR restores the check for the `sectionListRenderer` in order to fix this issue with music channels.

## Screenshots <!-- If appropriate -->
_before:_
![image](https://user-images.githubusercontent.com/106682128/199768392-7cf9cf7a-6e2b-4426-8a05-0412b30e3684.png)
_after:_
![image](https://user-images.githubusercontent.com/106682128/199767611-1d2adf80-92a2-4ffd-9545-f585d70ab89d.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Here are some examples of channels which qualify as "music" channels if you want to check them:
- [Linkin Park](https://www.youtube.com/channel/UCZU9T1ceaOgwfLRq7OKFU4Q)
- [My Chemical Romance](https://www.youtube.com/channel/UCCZGYab5SpD0I7Z5JqJZgww)
- [beegees](https://www.youtube.com/channel/UCD9sCcKXnFxMeuFoNayVxeQ)

## Additional Information
It might be worth adding a test which checks a music channel in order to make sure the response is not empty.

This issue was originally brought up by someone on the freetube matrix channel.