### PR TITLE
Add new methods to reflect YT feature change

### DIFF
--- a/app/fetchers/channel.js
+++ b/app/fetchers/channel.js
@@ -18,6 +18,12 @@ class YoutubeChannelFetcher {
     const channelPageResponse = await ytGrabHelp.decideUrlRequestType(channelId, 'videos?view=0&sort=p&flow=grid&pbj=1', channelIdType)
     return await ytGrabHelp.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
   }
+
+  static async getChannelList(channelId, channelIdType, tab = 'videos', httpAgent = null) {
+    const ytGrabHelp = helper.create(httpAgent)
+    const channelPageResponse = await ytGrabHelp.decideUrlRequestType(channelId, `${tab}?view=0&sort=p&flow=grid&pbj=1`, channelIdType)
+    return await ytGrabHelp.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
+  }
 }
 
 module.exports = YoutubeChannelFetcher

--- a/app/fetchers/channel.js
+++ b/app/fetchers/channel.js
@@ -19,7 +19,7 @@ class YoutubeChannelFetcher {
     return await ytGrabHelp.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)
   }
 
-  static async getChannelList(channelId, channelIdType, tab = 'videos', httpAgent = null) {
+  static async getChannelList(channelId, channelIdType, tab = 'videos', sortBy = 'newest', httpAgent = null) {
     const ytGrabHelp = helper.create(httpAgent)
     const channelPageResponse = await ytGrabHelp.decideUrlRequestType(channelId, `${tab}?view=0&sort=p&flow=grid&pbj=1`, channelIdType)
     return await ytGrabHelp.parseChannelVideoResponse(channelPageResponse.response, channelId, channelPageResponse.channelIdType)

--- a/app/helper.js
+++ b/app/helper.js
@@ -59,7 +59,7 @@ class YoutubeGrabberHelper {
     if (typeof (channelPageDataResponse) === 'undefined') {
       channelPageDataResponse = response.data[1].response
     }
-    if (typeof (channelPageDataResponse.alerts) !== 'undefined') {
+    if ('alerts' in channelPageDataResponse) {
       return {
         alertMessage: channelPageDataResponse.alerts[0].alertRenderer.text.simpleText
       }
@@ -190,9 +190,16 @@ class YoutubeGrabberHelper {
     let durationText
     let publishedText = ''
     if (typeof (obj.richItemRenderer) !== 'undefined') {
-      video = obj.richItemRenderer.content.videoRenderer
-      video.lengthSeconds = video.lengthText.simpleText.split(':').reduce((acc, time) => (60 * acc) + +time)
-      video.title.simpleText = video.title.runs[0].text
+      if ('videoRenderer' in obj.richItemRenderer.content) {
+        video = obj.richItemRenderer.content.videoRenderer
+        video.lengthSeconds = video.lengthText?.simpleText.split(':')?.reduce((acc, time) => (60 * acc) + +time)
+        video.title.simpleText = video.title.runs[0].text
+      }
+      if ('reelItemRenderer' in obj.richItemRenderer.content) {
+        video = obj.richItemRenderer.content.reelItemRenderer
+        video.title = video.headline
+        video.publishedTimeText = { simpleText: '' }
+      }
     } else if (typeof (obj.reelItemRenderer) !== 'undefined') {
       video = obj.reelItemRenderer
       video.title = video.headline
@@ -207,7 +214,7 @@ class YoutubeGrabberHelper {
 
     let title = video.title.simpleText
     let statusRenderer
-    if (!('channelVideoPlayerRenderer' in obj) && !('reelItemRenderer' in obj)) {
+    if (video.thumbnailOverlays) {
       statusRenderer = video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer
     }
 
@@ -243,7 +250,7 @@ class YoutubeGrabberHelper {
 
       publishedText = video.publishedTimeText.simpleText
 
-      if (!('channelVideoPlayerRenderer' in obj) && !('reelItemRenderer' in obj) && typeof (video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer) !== 'undefined') {
+      if (video.thumbnailOverlays && typeof (video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer) !== 'undefined') {
         durationText = video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer.text.simpleText
         const durationSplit = durationText.split(':')
 

--- a/app/helper.js
+++ b/app/helper.js
@@ -250,8 +250,8 @@ class YoutubeGrabberHelper {
 
       publishedText = video.publishedTimeText.simpleText
 
-      if (video.thumbnailOverlays && typeof (video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer) !== 'undefined') {
-        durationText = video.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer.text.simpleText
+      if (video.thumbnailOverlays && typeof (statusRenderer) !== 'undefined') {
+        durationText = statusRenderer.text.simpleText
         const durationSplit = durationText.split(':')
 
         if (durationSplit.length === 3) {

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -224,6 +224,14 @@ class YoutubeGrabber {
     }
   }
 
+  static async getChannelLivestreams({ channelId, channelIdType = 0, httpAgent = null }) {
+    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'streams', httpAgent)
+  }
+
+  static async getChannelShorts({ channelId, channelIdType = 0, httpAgent = null }) {
+    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'shorts', httpAgent)
+  }
+
   static async getChannelVideosMore({ continuation, httpAgent = null }) {
     const ytGrabHelp = YoutubeGrabberHelper.create(httpAgent)
     const urlParams = this.GetContinuationUrlParams(continuation)

--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -224,12 +224,12 @@ class YoutubeGrabber {
     }
   }
 
-  static async getChannelLivestreams({ channelId, channelIdType = 0, httpAgent = null }) {
-    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'streams', httpAgent)
+  static async getChannelLivestreams({ channelId, sortBy = 'newest', channelIdType = 0, httpAgent = null }) {
+    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'streams', sortBy, httpAgent)
   }
 
-  static async getChannelShorts({ channelId, channelIdType = 0, httpAgent = null }) {
-    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'shorts', httpAgent)
+  static async getChannelShorts({ channelId, sortBy = 'newest', channelIdType = 0, httpAgent = null }) {
+    return await YoutubeChannelFetcher.getChannelList(channelId, channelIdType, 'shorts', sortBy, httpAgent)
   }
 
   static async getChannelVideosMore({ continuation, httpAgent = null }) {

--- a/test/channelVideos.test.js
+++ b/test/channelVideos.test.js
@@ -51,6 +51,13 @@ describe('Getting channel videos', () => {
     })
   })
 
+  test('Live channel', () => {
+    const parameters = { channelId: 'UCSJ4gkVC6NrvII8umztf0Ow', channelIdType: 1 }
+    return ytch.getChannelVideos(parameters).then((data) => {
+      expect(data.items.filter((item) => item.liveNow).length).not.toBe(0)
+    })
+  })
+
   test('Upcoming video', () => {
     // https://www.youtube.com/channel/UCUKPG1-r4WFyxpyhIuCs86Q
     // This channel has a video premiering in 2024/3/31

--- a/test/channelVideos.test.js
+++ b/test/channelVideos.test.js
@@ -32,7 +32,7 @@ describe('Getting channel videos', () => {
 
   test('Shorts Channel', () => {
     const parameters = { channelId: 'UC4-79UOlP48-QNGgCko5p2g', channelIdType: 1 }
-    return ytch.getChannelVideos(parameters).then((data) => {
+    return ytch.getChannelShorts(parameters).then((data) => {
       expect(data.items.length).not.toBe(0)
     })
   })
@@ -53,7 +53,7 @@ describe('Getting channel videos', () => {
 
   test('Live channel', () => {
     const parameters = { channelId: 'UCSJ4gkVC6NrvII8umztf0Ow', channelIdType: 1 }
-    return ytch.getChannelVideos(parameters).then((data) => {
+    return ytch.getChannelLivestreams(parameters).then((data) => {
       expect(data.items.filter((item) => item.liveNow).length).not.toBe(0)
     })
   })


### PR DESCRIPTION
# Add new methods `getChannelShorts` and `getChannelLivestreams`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Up until somewhat recently, the "Videos" tab on channel pages would show videos, shorts, and live-streams; however, shorts and live-streams get their own tabs now. If a channel has no videos, the URL which videos are fetched from will redirect to the channel homepage. The result is that ***some*** shorts and live-streams are fetched from those channels, and this is the reason why the shorts test didn't fail even though most channels with shorts aren't returning shorts at all.  *Mr. Beast Shorts*, the channel used in the shorts test, only has shorts, and so, the test passes.

This PR aims to address the underlying issue by simply adding two new methods to allow live-streams and shorts to be fetched with their own calls. Code that uses this library may have to be updated in order to achieve the same results as before the layout change, but I believe that the manner in which it will need to be updated is much more straightforward than if we cobbled together three different responses in an attempt to recreate the functionality which existed before the layout change. No existing methods would change, but for instance, FreeTube would have to be updated in order to include these new tabs.

## Additional Information
I don't believe there is a way to return shorts and live-streams along with the videos without making multiple requests. On top of that, both of those tabs could have their own continuations which would make it difficult to simply return a combined list without introducing some sort of paging issue. This is why I believe it is important to have separate methods.

I didn't address sorting whatsoever because it is now handled [through continuations](https://github.com/FreeTubeApp/FreeTube/issues/2805#issuecomment-1302217353), and I felt that those changes are out of the scope of this PR. I'm pretty much certain there is a way to generate the continuation tokens for sorting without making a page request to YT, but I haven't figured it out. [I know that Invidious generates its own continuation tokens](https://github.com/iv-org/invidious/blob/master/src/invidious/channels/videos.cr), but [that stopped working](https://invidious.sethforprivacy.com/channel/UCeeFfhMcJa1kjtfZAGskOCA?page=1&sort_by=popular) 🤷‍♀️. The tokens seem to be identical for the same channel and sort type, so there has to be a way to construct that token out of the channel information combined with a flag of some kind. A workaround for not having this information might be to simply expose the continuation tokens used for filtering out of the initial response in order to treat them like any other continuation. The `getChannelVideosMore` method would pull that data easily; however, that would create breaking changes for sorting, so I'm not super attached to that workaround. These two requests to the channel page could also be made silently under the existing `sortBy` implementation without introducing any breaking changes, but I'm also not sure if that is the best way of solving this problem.